### PR TITLE
ファイルリストを格納する配列を追加し、取得したファイルをURLに変換・格納。

### DIFF
--- a/scandir.php
+++ b/scandir.php
@@ -16,6 +16,7 @@ $file_list = [];
 $files = scandir($directory);
 // var_dump($files);
 
+// 取得したファイルをURLに変換するためforeachで展開。
 foreach($files as $file) {
     // var_dump($file);
 

--- a/scandir.php
+++ b/scandir.php
@@ -10,7 +10,22 @@ $directory = $_SERVER['DOCUMENT_ROOT'] . '/work-product/';
 // WEB上のルートURL。「$base_url」+「ファイル名」でURLの生成。
 $base_url = 'https://lgqqi65169.rakkoserver.net/work-product/';
 
+// ファイルリストを格納する配列
+$file_list = [];
+
 $files = scandir($directory);
 // var_dump($files);
+
+foreach($files as $file) {
+    // var_dump($file);
+
+    $file_url = $base_url . $file;
+    // var_dump($file_url);
+
+    // 取得したファイルを配列に格納
+    $file_list[] = $file_url;
+}
+// var_dump($file_url);
+var_dump($file_list);
 
 ?>


### PR DESCRIPTION
###メモ
- URLに変換するためforeachで展開
- 変換したURLを配列に格納

URLに加工するために、scandirファイルをforeachで展開。
変数に入れてforeachの外で呼び出すと、一番最後のファイルだけ出力される模様。
foreach内のデータを外に持ち出す時は、配列に格納しないとだめっぽい。