### PR TITLE
開発用サーバーの設定を追加し、APIリクエストのプロキシ設定を整備

### DIFF
--- a/vue-work-product/vite.config.ts
+++ b/vue-work-product/vite.config.ts
@@ -6,13 +6,28 @@ import vueDevTools from 'vite-plugin-vue-devtools'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [
-    vue(),
-    vueDevTools(),
-  ],
+  plugins: [vue(), vueDevTools()],
   resolve: {
     alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+
+  // 開発用サーバーの設定
+  server: {
+    // APIリクエストをPHPバックエンドに転送するプロキシ設定
+    proxy: {
+      // '/api' から始まるリクエストをプロキシする
+      '/api': {
+        // PHPファイルが動作しているWebサーバーのURLを指定
+        target: 'https://lgqqi65169.rakkoserver.net',
+        // '/api/scandir.php' を '/php/scandir.php' に書き換える
+        rewrite: (path) => path.replace(/^\/api/, '/php'),
+        // WebSocketのプロキシ設定
+        ws: true,
+        // オリジンヘッダーをターゲットのURLに変更する
+        changeOrigin: true,
+      },
     },
   },
 })


### PR DESCRIPTION
開発用のサーバーから、https://lgqqi65169.rakkoserver.netにアクセスできるようプロキシの設定。
のコピペ。

設定方法は分からないが、設定が必要なことは理解。
ビルドツールがViteなので、vite.config.tsへ設定追加。